### PR TITLE
Add missing fields for baremetal servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/google/go-cmp v0.6.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,12 @@ github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM
 github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
 golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.28.0 h1:WuB6qZ4RPCQo5aP3WdKZS7i595EdWqWR8vqJTlwTVK8=

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -115,6 +115,7 @@ type ConfigurationDetails struct {
 // DedicatedServer represents dedicated server
 type DedicatedServer struct {
 	ID                   string               `json:"id"`
+	RackID               string               `json:"rack_id"`
 	Type                 string               `json:"type"`
 	Title                string               `json:"title"`
 	LocationID           int64                `json:"location_id"`
@@ -125,7 +126,9 @@ type DedicatedServer struct {
 	Configuration        string               `json:"configuration"`
 	PrivateIPv4Address   *string              `json:"private_ipv4_address"`
 	PublicIPv4Address    *string              `json:"public_ipv4_address"`
+	LeaseStart           string               `json:"lease_start_at"`
 	ScheduledRelease     *time.Time           `json:"scheduled_release_at"`
+	OobIPv4Address       string               `json:"oob_ipv4_address"`
 	ConfigurationDetails ConfigurationDetails `json:"configuration_details"`
 	Labels               map[string]string    `json:"labels"`
 	Created              time.Time            `json:"created_at"`
@@ -134,27 +137,34 @@ type DedicatedServer struct {
 
 // KubernetesBaremetalNode represents kubernetes baremetal node
 type KubernetesBaremetalNode struct {
-	ID                   string               `json:"id"`
-	Type                 string               `json:"type"`
-	Title                string               `json:"title"`
-	LocationID           int64                `json:"location_id"`
-	LocationCode         string               `json:"location_code"`
-	Status               string               `json:"status"`
-	OperationalStatus    string               `json:"operational_status"`
-	PowerStatus          string               `json:"power_status"`
-	Configuration        string               `json:"configuration"`
-	PrivateIPv4Address   *string              `json:"private_ipv4_address"`
-	PublicIPv4Address    *string              `json:"public_ipv4_address"`
-	ScheduledRelease     *time.Time           `json:"scheduled_release_at"`
-	ConfigurationDetails ConfigurationDetails `json:"configuration_details"`
-	Labels               map[string]string    `json:"labels"`
-	Created              time.Time            `json:"created_at"`
-	Updated              time.Time            `json:"updated_at"`
+	ID                          string               `json:"id"`
+	KubernetesClusterID         string               `json:"kubernetes_cluster_id"`
+	KubernetesClusterNodeID     string               `json:"kubernetes_cluster_node_id"`
+	KubernetesClusterNodeNumber int64                `json:"kubernetes_cluster_node_number"`
+	RackID                      string               `json:"rack_id"`
+	Type                        string               `json:"type"`
+	Title                       string               `json:"title"`
+	LocationID                  int64                `json:"location_id"`
+	LocationCode                string               `json:"location_code"`
+	Status                      string               `json:"status"`
+	OperationalStatus           string               `json:"operational_status"`
+	PowerStatus                 string               `json:"power_status"`
+	Configuration               string               `json:"configuration"`
+	PrivateIPv4Address          *string              `json:"private_ipv4_address"`
+	PublicIPv4Address           *string              `json:"public_ipv4_address"`
+	LeaseStart                  string               `json:"lease_start_at"`
+	ScheduledRelease            *time.Time           `json:"scheduled_release_at"`
+	OobIPv4Address              string               `json:"oob_ipv4_address"`
+	ConfigurationDetails        ConfigurationDetails `json:"configuration_details"`
+	Labels                      map[string]string    `json:"labels"`
+	Created                     time.Time            `json:"created_at"`
+	Updated                     time.Time            `json:"updated_at"`
 }
 
 // SBMServer represents scalable baremetal server
 type SBMServer struct {
 	ID                   string               `json:"id"`
+	RackID               string               `json:"rack_id"`
 	Type                 string               `json:"type"`
 	Title                string               `json:"title"`
 	LocationID           int64                `json:"location_id"`
@@ -165,7 +175,9 @@ type SBMServer struct {
 	Configuration        string               `json:"configuration"`
 	PrivateIPv4Address   *string              `json:"private_ipv4_address"`
 	PublicIPv4Address    *string              `json:"public_ipv4_address"`
+	LeaseStart           string               `json:"lease_start_at"`
 	ScheduledRelease     *time.Time           `json:"scheduled_release_at"`
+	OobIPv4Address       string               `json:"oob_ipv4_address"`
 	ConfigurationDetails ConfigurationDetails `json:"configuration_details"`
 	Labels               map[string]string    `json:"labels"`
 	Created              time.Time            `json:"created_at"`


### PR DESCRIPTION
Bump pkgs.

Add next fields for dedicated server and SBM server:
```
lease_start_at
rack_id
oob_ipv4_address
```

Add next fields for kubernetes baremetal:
```
lease_start_at
rack_id
oob_ipv4_address
kubernetes_cluster_id
kubernetes_cluster_node_id
kubernetes_cluster_node_number
```